### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,7 @@
 pyttsx3==2.90
 SpeechRecognition==3.8.1
-webbrowser==0.0.1
 pywhatkit==5.4
-smtplib==0.3.0
-email==6.0.0a1
 requests==2.31.0
-shlex==3.8
 google-generativeai==0.2.0
 pyaudio==0.2.13
 pocketsphinx==0.1.15


### PR DESCRIPTION
`webbrowser` and `shlex` not part of Python standard library
`email`, `smtplib` are part of Python standard library, so already installed.